### PR TITLE
fix raised paperclip error

### DIFF
--- a/spec/support/post.rb
+++ b/spec/support/post.rb
@@ -6,6 +6,7 @@ class Post < ActiveRecord::Base
   include Paperclip::Glue
 
   has_attached_file :attachment
+  do_not_validate_attachment_file_type :attachment
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Since paperclip 4.0, all attachments are required to include a content_type validation, a file_name validation, or to explicitly state that they're not going to have either. Paperclip will raise an error if you do not do this. This make failed specs in the gem.

But for testing, we can just explicitly not validate through `do_not_validate_attachment_file_type`.
