### PR TITLE
Create interpolations for urls

### DIFF
--- a/lib/paperclip/storage/aliyun.rb
+++ b/lib/paperclip/storage/aliyun.rb
@@ -2,12 +2,13 @@ module Paperclip
   module Storage
     module Aliyun
       def self.extended(base)
+        Paperclip.interpolates(:aliyun_path_url) do |attachment, style|
+          "http://#{attachment.oss_connection.fetch_file_host}/#{attachment.path(style).gsub(%r{\A/}, "")}"
+        end unless Paperclip::Interpolations.respond_to? :aliyun_path_url
       end
 
       def exists?(style = default_style)
-        return false unless path(style)
-
-        oss_connection.exists? path(style)
+        path(style) ? oss_connection.exists?(path(style)) : false
       end
 
       def flush_writes #:nodoc:
@@ -37,8 +38,6 @@ module Paperclip
       end
 
       def oss_connection
-        return @oss_connection if @oss_connection
-
         @oss_connection ||= ::Aliyun::Connection.new Paperclip::Attachment.default_options[:aliyun]
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,13 +2,10 @@ require 'pry'
 require 'pry-nav'
 require 'paperclip-storage-aliyun'
 
-Dir[File.join(Bundler.root, "spec/support/**/*.rb")].each &method(:require)
+Paperclip.logger.level = ::Logger::UNKNOWN
+Dir[Bundler.root.join('spec/support/**/*.rb')].each(&method(:require))
 
-include Paperclip::Storage::Aliyun
-def file_host
-  oss_connection.fetch_file_host
-end
-
+# Aliyun defaults
 OSS_CONNECTION_OPTIONS = {
   access_id: '3VL9XMho8iCuslj8',
   access_key: 'VAUI2q7Tc6yTf1jr3kBsEUzZ84gEa2',
@@ -18,12 +15,13 @@ OSS_CONNECTION_OPTIONS = {
   # host: nil
 }
 
-# paperclip初始化设置
+# Paperclip defaults
 Paperclip::Attachment.default_options[:storage] = :aliyun
-Paperclip::Attachment.default_options[:path] = 'public/system/:class/:attachment/:id_partition/:style/:filename'
 Paperclip::Attachment.default_options[:aliyun] = OSS_CONNECTION_OPTIONS
-Paperclip::Attachment.default_options[:url] = "http://#{file_host}/public/system/:class/:attachment/:id_partition/:style/:filename"
+Paperclip::Attachment.default_options[:path] = 'public/system/:class/:attachment/:id_partition/:style/:filename'
+Paperclip::Attachment.default_options[:url] = ':aliyun_path_url'
 
+# Utility methods
 def load_attachment(file_name)
-  File.open (File.expand_path "attachments/#{file_name}", File.dirname(__FILE__)), 'rb'
+  File.open(Bundler.root.join("spec/attachments/#{file_name}"), 'rb')
 end


### PR DESCRIPTION
No more need to `include Paperclip::Storage::Aliyun` and close #8.

References
- https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/s3.rb#L69
- https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/s3.rb#L184