### PR TITLE
Fixed missing URI.encode in head

### DIFF
--- a/lib/aliyun/connection.rb
+++ b/lib/aliyun/connection.rb
@@ -93,7 +93,7 @@ module Aliyun
         'Host' => @aliyun_upload_host,
         'Expect' => '100-Continue'
       }
-      response = RestClient.put(URI.encode(url), file, headers)
+      response = RestClient.put(url, file, headers)
       response.code == 200 ? path_to_url(path) : nil
     end
 
@@ -113,7 +113,7 @@ module Aliyun
         'Authorization' => sign('DELETE', bucket_path, '', '', date)
       }
       url = path_to_url(path)
-      response = RestClient.delete(URI.encode(url), headers)
+      response = RestClient.delete(url, headers)
       response.code == 204 ? url : nil
     end
 
@@ -132,7 +132,7 @@ module Aliyun
         'Authorization' => sign('GET', bucket_path, '', '', date)
       }
       url = path_to_url(path)
-      response = RestClient.get(URI.encode(url), headers)
+      response = RestClient.get(url, headers)
       response.body
     end
 
@@ -176,7 +176,7 @@ module Aliyun
     # @param path [String] the path to retrieve the file on remote storage
     # @return [String] the expected full path, e.g. "http://martin-test.oss-cn-hangzhou.aliyuncs.com/oss-api.pdf"
     def path_to_url(path)
-      path =~ %r{^https?://} ? path : "http://#{aliyun_upload_host}/#{path}"
+      path =~ %r{^https?://} ? path : URI.encode("http://#{aliyun_upload_host}/#{path}")
     end
 
     private

--- a/paperclip-storage-aliyun.gemspec
+++ b/paperclip-storage-aliyun.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.summary      = 'Extend a Aliyun OSS storage for paperclip'
   s.description  = 'Extend a Aliyun OSS storage for paperclip'
-  s.version      = '0.1.0'
+  s.version      = '0.1.1'
   s.files        = `git ls-files`.split("\n")
   s.authors      = ['Martin Hong', 'Aidi Stan']
   s.email        = 'hongzeqin@gmail.com'

--- a/paperclip-storage-aliyun.gemspec
+++ b/paperclip-storage-aliyun.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.summary      = 'Extend a Aliyun OSS storage for paperclip'
   s.description  = 'Extend a Aliyun OSS storage for paperclip'
-  s.version      = '0.0.3'
+  s.version      = '0.1.0'
   s.files        = `git ls-files`.split("\n")
   s.authors      = ['Martin Hong', 'Aidi Stan']
   s.email        = 'hongzeqin@gmail.com'


### PR DESCRIPTION
This line misses `URI.encode` and cases problem when utf-8 url
```
RestClient.head(url).headers
```
Move encode to `path_to_url` and fix it.