### PR TITLE
New Data Centers And Data Center Finding Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Paperclip::Attachment.default_options[:aliyun] = {
   access_id: '3VL9XMho8iCushj8',
   access_key: 'VAUI2q7Tc6yTh1jr3kBsEUzZ84gEa2',
   bucket: 'xx-test',
-  data_center: 'hangzhou',
+  data_center: 'cn-hangzhou',
   internal: false,
   protocol: 'https'
 }
@@ -46,6 +46,10 @@ Similar to Paperclip::Storage::S3, there are four options for the url by now:
 - `:aliyun_alias_url` : the alias url based on the `host_alias` you give, typically used together with CDN
 
 Please note the values above are all strings, not symbols. You could still make your own url if only you know what you are doing.
+
+#### Data Centers
+A list of available regions can be found at [https://intl.aliyun.com/help/doc-detail/31837.htm](https://intl.aliyun.com/help/doc-detail/31837.htm).
+You can use the "Region Expression" column value as it is for the data center, or you can remove the "oss-" prefix. For example: `oss-cn-hangzhou` and `cn-hangzhou` are both valid options.
 
 #### Test
 1. Update connection settings in `spec/spec_helper.rb`:

--- a/lib/aliyun/connection.rb
+++ b/lib/aliyun/connection.rb
@@ -26,7 +26,7 @@ module Aliyun
     # @option access_id [String] used to set "Authorization" request header
     # @option access_key [String] the access key
     # @option bucket [String] bucket used to access
-    # @option data_center [String] available data center name, e.g. 'hangzhou'
+    # @option data_center [String] available data center name, e.g. 'cn-hangzhou'
     # @option internal [true, false] if the service should be accessed through internal network
     # @option host_alias [String] the alias of the host, such as the CDN domain name
     # @note both access_id and acces_key are related to authorization algorithm:

--- a/lib/aliyun/data_center.rb
+++ b/lib/aliyun/data_center.rb
@@ -5,13 +5,18 @@ module Aliyun
     # https://docs.aliyun.com/#/pub/oss/product-documentation/domain-region
     AVAILABLE_DATA_CENTERS = %w(
       oss-cn-hangzhou
+      oss-cn-shanghai
       oss-cn-qingdao
       oss-cn-beijing
-      oss-cn-hongkong
       oss-cn-shenzhen
-      oss-cn-shanghai
+      oss-cn-hongkong
       oss-us-west-1
+      oss-us-east-1
       oss-ap-southeast-1
+      oss-ap-southeast-2
+      oss-ap-northeast-1
+      oss-eu-central-1
+      oss-me-east-1
     )
 
     def get_endpoint(options)

--- a/lib/aliyun/data_center.rb
+++ b/lib/aliyun/data_center.rb
@@ -20,20 +20,15 @@ module Aliyun
     )
 
     def get_endpoint(options)
-      data_center = find_center(options[:data_center])
+      data_center = options[:data_center]
 
-      unless data_center && AVAILABLE_DATA_CENTERS.include?(data_center)
+      data_center.prepend('oss-') unless data_center.match(/^oss/)
+
+      unless AVAILABLE_DATA_CENTERS.include?(data_center)
         fail InvalildDataCenter, "Unsupported Data Center #{options[:data_center]} Detected"
       end
 
       "#{data_center}#{options[:internal] ? '-internal' : ''}.aliyuncs.com"
-    end
-
-    def find_center(data_center)
-      return if /^(oss|cn|us|ap|oss-cn)$/.match(data_center)
-
-      regexp = Regexp.new(data_center)
-      AVAILABLE_DATA_CENTERS.find { |center| regexp.match(center) }
     end
   end
 end

--- a/spec/aliyun_spec.rb
+++ b/spec/aliyun_spec.rb
@@ -14,6 +14,12 @@ describe Aliyun::Connection do
         ::Aliyun::Connection.new data_center: 'guangzhou'
       end.to raise_error(Aliyun::InvalildDataCenter)
     end
+
+    it 'raises an error when using ambiguous data center' do
+      expect do
+        ::Aliyun::Connection.new data_center: 'hangzhou'
+      end.to raise_error(Aliyun::InvalildDataCenter)
+    end
   end
 
   describe '#put' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ OSS_CONNECTION_OPTIONS = {
   access_id: '4adTRa4dWto3vxiq',
   access_key: 'hzEWBDWlt3N0SPPj6EfYAr4ISdaizW',
   bucket: 'martin-test',
-  data_center: 'hangzhou',
+  data_center: 'cn-hangzhou',
   internal: false
   # host_alias: nil
 }


### PR DESCRIPTION
I added some new data centers that were missing from the list of available centers. I also noticed that there were many cases where the old method for finding centers might actually fail unintentionally, e.g. using "1" or "east" as a center wouldn't have failed but would've given an ambiguous reference.

The cleaned up method might introduce breaking changes for users who use the last part of the name of the center to refer to it, but I felt it was a justified compromise.

If this change is OK, I can also edit the README to reflect those changes.